### PR TITLE
Allow usage with Bioconductor 3.5 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,10 +18,10 @@ Encoding: UTF-8
 LazyData: TRUE
 Depends:
     R (>= 3.4.0),
-    SummarizedExperiment (>= 1.8.0)
+    SummarizedExperiment (>= 1.6.5)
 Imports:
     basejump (>= 0.1.5),
-    BiocGenerics (>= 0.24.0),
+    BiocGenerics (>= 0.22.1),
     cowplot (>= 0.8.0),
     dendsort (>= 0.3.3),
     dplyr (>= 0.7.4),
@@ -37,7 +37,7 @@ Imports:
     pbapply (>= 1.3),
     pheatmap (>= 1.0.8),
     rlang (>= 0.1.2),
-    S4Vectors (>= 0.16.0),
+    S4Vectors (>= 0.14.7),
     scales,
     Seurat (>= 2.1.0),
     stats,

--- a/R/methods-plotMarkerTSNE.R
+++ b/R/methods-plotMarkerTSNE.R
@@ -11,6 +11,7 @@
 #'
 #' @param colorPoints Color points by geometric mean (`geomean`) or expression
 #'   of individual gene (`expression`).
+#' @param legend Show plot legend.
 #'
 #' @return [ggplot].
 #'

--- a/man/plotMarkerTSNE.Rd
+++ b/man/plotMarkerTSNE.Rd
@@ -41,6 +41,8 @@ low/high gradient.}
 
 \item{dark}{Enable dark mode.}
 
+\item{legend}{Show plot legend.}
+
 \item{title}{Plot title.}
 
 \item{genes}{Genes (by symbol name) of which to get expression data.}


### PR DESCRIPTION
Downgraded SummarizedExperiment, BiocGenerics, and S4Vectors to Bioconductor 3.5 release versions.