### PR TITLE
supplied annotable doesn't take uniqueSymbol option

### DIFF
--- a/R/loadSingleCell.R
+++ b/R/loadSingleCell.R
@@ -374,7 +374,7 @@ loadSingleCell <- function(
             release = ensemblVersion,
             uniqueSymbol = FALSE)
     } else if (is.data.frame(annotable)) {
-        annotable <- annotable(annotable, uniqueSymbol = FALSE)
+        annotable <- annotable(annotable)
     } else {
         warn("Loading run without gene annotable")
         annotable <- NULL


### PR DESCRIPTION
If you supply a dataframe, the uniqueSymbol option is not used.