### PR TITLE
Fix description of y-axis for reads per cell histogram.

### DIFF
--- a/R/plotReadsPerCell-methods.R
+++ b/R/plotReadsPerCell-methods.R
@@ -291,7 +291,7 @@ NULL
         ) +
         labs(
             x = "log10 reads per cell",
-            y = "proportion of cells"
+            y = "proportion of reads"
         )
 
     # Cutoff line

--- a/inst/rmarkdown/templates/quality_control/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/quality_control/skeleton/skeleton.Rmd
@@ -67,9 +67,15 @@ These are counts of how many reads are assigned to a given cellular barcode. It 
 
 ## Histogram
 
-For high quality data, the proportional histogram should contain a single large peak that represents cells that were encapsulated. If we see a strong shoulder, or a bimodal distribution of the cells, that can indicate a couple problems. It might be that there is free floating RNA, which happens when cells are dying. It could also be that there are a set of cells that failed for some reason. Finally, it could also be that there are biologically different types of cells, and one type is much smaller than the other. If this is the case we would expect to see less RNA being sequenced from the smaller cells.
-
-It looks like there a lot of low complexity barcodes that need to be filtered out, but we can see cells with a usable read depth of at least 10,000 (10^4) reads per cell.
+For high quality data, the proportional histogram should contain a single large
+peak that represents reads from cells that were encapsulated. If we see a strong
+shoulder, or a bimodal distribution of the reads, that can indicate a couple
+problems. It might be that there is free floating RNA, which happens when cells
+are dying. It could also be that there are a set of cells that failed for some
+reason. Finally, it could also be that there are biologically different types of
+cells, and one type is much smaller than the other. If this is the case we would
+expect to see less reads because there is less RNA to be sequenced from the
+smaller cells.
 
 ```{r plot_reads_per_cell_histogram}
 # getMethod("plotReadsPerCell", "bcbioSingleCell")


### PR DESCRIPTION
The area under these curves are the total reads, not the total cells. So if there is a peak at 10^4 for example, that is a proportion of 0.4, what that is saying is cells that have 10^4 reads account for 40% of the reads, not 40% of the cells.